### PR TITLE
feat: add entropy-based anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ Real-time threat detection with 5 built-in algorithms:
 5. **ARP Spoofing** - Monitors IP-to-MAC mapping changes (Severity: CRITICAL)
 - Real-time SnackBar alerts in the Flutter UI showing severity, type, source IP, and description
 
+**Entropy Analysis** (Shannon entropy on every payload ≥ 32 bytes):
+- DNS tunneling detected: dnscat2, iodine signatures (entropy > 5.5 in DNS queries)
+- ICMP covert channels detected: icmptunnel, ptunnel (entropy > 6.0 in ICMP payloads)
+- HTTP/plain-protocol data exfiltration detected (entropy > 7.2)
+- Suspicious encoding in HTTP/DNS flagged at medium severity (entropy 6.5–7.2)
+- Entropy score visible as a badge (`E:x.x`) on each packet in the capture UI
+
 ###  **Traffic Statistics & Analytics**
 - Real-time metrics (packets/sec, bytes/sec, connections)
 - Protocol distribution charts

--- a/android/app/src/main/kotlin/com/example/packet_analyzer/AnomalyDetector.kt
+++ b/android/app/src/main/kotlin/com/example/packet_analyzer/AnomalyDetector.kt
@@ -20,6 +20,11 @@ object AnomalyDetector {
     private const val CONNECTION_RATE_THRESHOLD = 50
     private const val DNS_QUERY_THRESHOLD = 30
 
+    // Entropy analysis thresholds
+    private const val ENTROPY_THRESHOLD_HIGH = 7.2
+    private const val ENTROPY_THRESHOLD_SUSPICIOUS = 6.5
+    private const val MIN_PAYLOAD_SIZE_FOR_ENTROPY = 32
+
     // ML-based data structures
     private val trafficStats = TrafficStatistics()
     private val behavioralAnalyzer = BehavioralAnalyzer()
@@ -79,7 +84,7 @@ object AnomalyDetector {
 
     enum class AnomalyType {
         PORT_SCAN, SYN_FLOOD, ARP_SPOOFING, DNS_TUNNELING, CONNECTION_FLOOD,
-        UNUSUAL_TRAFFIC, MALFORMED_PACKET
+        UNUSUAL_TRAFFIC, MALFORMED_PACKET, HIGH_ENTROPY_PAYLOAD, COVERT_CHANNEL
     }
 
     enum class Severity { LOW, MEDIUM, HIGH, CRITICAL }
@@ -113,6 +118,20 @@ object AnomalyDetector {
 
     fun removeAnomalyListener(listener: (Anomaly) -> Unit) {
         anomalyListeners.remove(listener)
+    }
+
+    fun calculateEntropy(payload: ByteArray): Double {
+        if (payload.isEmpty()) return 0.0
+        val frequency = IntArray(256)
+        for (byte in payload) frequency[byte.toInt() and 0xFF]++
+        val size = payload.size.toDouble()
+        return frequency.fold(0.0) { entropy, count ->
+            if (count == 0) entropy
+            else {
+                val p = count / size
+                entropy - p * log2(p)
+            }
+        }
     }
 
     fun calculateAnomalyScore(packetInfo: Map<String, Any>): Double {
@@ -203,9 +222,16 @@ object AnomalyDetector {
                 )
             }
 
-            // === 4. ML-Based Detection (Stubs) ===
+            // === 4. Entropy-Based Detection ===
+            if (payload != null && payload.size >= MIN_PAYLOAD_SIZE_FOR_ENTROPY) {
+                val appName = packetInfo["appName"] as? String
+                checkDnsTunneling(payload, protocol, sourceIp, destIp)
+                checkHighEntropyPayload(payload, protocol, appName, sourceIp, destIp)
+                (packetInfo as? MutableMap<String, Any>)?.put("entropyScore", calculateEntropy(payload))
+            }
+
+            // === 5. ML-Based Detection (Stubs) ===
             detectBehavioralAnomalies(packetInfo)
-            detectEntropyAnomalies(packetInfo, payload)
             detectConnectionPatternAnomalies(packetInfo)
             updateTrafficStatistics(packetInfo, payload)
             updateBehavioralModels(packetInfo)
@@ -274,6 +300,76 @@ object AnomalyDetector {
         }
     }
 
+    private fun checkHighEntropyPayload(
+        payload: ByteArray,
+        protocol: String,
+        appName: String?,
+        sourceIp: String,
+        destinationIp: String
+    ) {
+        if (payload.size < MIN_PAYLOAD_SIZE_FOR_ENTROPY) return
+        if (protocol.isEmpty()) return
+        // TLS, QUIC, HTTPS are always high entropy — skip to avoid false positives
+        if (protocol == "TLS" || protocol == "QUIC" || protocol == "HTTPS") return
+
+        val entropy = calculateEntropy(payload)
+        when {
+            protocol == "ICMP" && entropy > 6.0 -> reportAnomaly(
+                Anomaly(
+                    type = AnomalyType.COVERT_CHANNEL,
+                    severity = Severity.CRITICAL,
+                    description = "ICMP payload entropy ${"%.2f".format(entropy)} — possible icmptunnel/ptunnel covert channel",
+                    sourceIp = sourceIp,
+                    destinationIp = destinationIp
+                )
+            )
+            (protocol == "HTTP" || protocol == "DNS") && entropy > ENTROPY_THRESHOLD_HIGH -> reportAnomaly(
+                Anomaly(
+                    type = AnomalyType.HIGH_ENTROPY_PAYLOAD,
+                    severity = Severity.HIGH,
+                    description = "High entropy ${"%.2f".format(entropy)} in $protocol payload — possible exfiltration",
+                    sourceIp = sourceIp,
+                    destinationIp = destinationIp
+                )
+            )
+            (protocol == "HTTP" || protocol == "DNS") && entropy > ENTROPY_THRESHOLD_SUSPICIOUS -> reportAnomaly(
+                Anomaly(
+                    type = AnomalyType.HIGH_ENTROPY_PAYLOAD,
+                    severity = Severity.MEDIUM,
+                    description = "Suspicious entropy ${"%.2f".format(entropy)} in $protocol payload",
+                    sourceIp = sourceIp,
+                    destinationIp = destinationIp
+                )
+            )
+            entropy > ENTROPY_THRESHOLD_HIGH -> reportAnomaly(
+                Anomaly(
+                    type = AnomalyType.HIGH_ENTROPY_PAYLOAD,
+                    severity = Severity.MEDIUM,
+                    description = "Unexpected high entropy ${"%.2f".format(entropy)} in $protocol — investigate",
+                    sourceIp = sourceIp,
+                    destinationIp = destinationIp
+                )
+            )
+        }
+    }
+
+    private fun checkDnsTunneling(payload: ByteArray, protocol: String, sourceIp: String, destinationIp: String) {
+        if (protocol != "DNS") return
+        if (payload.size < MIN_PAYLOAD_SIZE_FOR_ENTROPY) return
+        val entropy = calculateEntropy(payload)
+        if (entropy > 5.5) {
+            reportAnomaly(
+                Anomaly(
+                    type = AnomalyType.DNS_TUNNELING,
+                    severity = Severity.HIGH,
+                    description = "DNS query entropy ${"%.2f".format(entropy)} suggests tunneling tool (dnscat2/iodine)",
+                    sourceIp = sourceIp,
+                    destinationIp = destinationIp
+                )
+            )
+        }
+    }
+
     private fun detectDnsTunneling(queryName: String) {
         if (queryName.isEmpty()) return
         if (queryName.length > 50) {
@@ -301,9 +397,8 @@ object AnomalyDetector {
         for (listener in anomalyListeners) listener(anomaly)
     }
 
-    // === Dummy Functional Replacements (to fix missing references) ===
+    // === Stubs for future ML-based detection ===
     private fun detectBehavioralAnomalies(packetInfo: Map<String, Any>) {}
-    private fun detectEntropyAnomalies(packetInfo: Map<String, Any>, payload: ByteArray?) {}
     private fun detectConnectionPatternAnomalies(packetInfo: Map<String, Any>) {}
     private fun updateTrafficStatistics(packetInfo: Map<String, Any>, payload: ByteArray?) {}
     private fun updateBehavioralModels(packetInfo: Map<String, Any>) {}

--- a/android/app/src/main/kotlin/com/example/packet_analyzer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/packet_analyzer/MainActivity.kt
@@ -363,6 +363,8 @@ class MainActivity : FlutterFragmentActivity() {
             AnomalyDetector.AnomalyType.CONNECTION_FLOOD -> "Connection Flood Attack"
             AnomalyDetector.AnomalyType.UNUSUAL_TRAFFIC -> "Suspicious Network Activity"
             AnomalyDetector.AnomalyType.MALFORMED_PACKET -> "Malformed Packet Detected"
+            AnomalyDetector.AnomalyType.HIGH_ENTROPY_PAYLOAD -> "High Entropy Payload Detected"
+            AnomalyDetector.AnomalyType.COVERT_CHANNEL -> "Covert Channel Detected"
         }
     }
     

--- a/android/app/src/main/kotlin/com/example/packet_analyzer/PacketAnalysisManager.kt
+++ b/android/app/src/main/kotlin/com/example/packet_analyzer/PacketAnalysisManager.kt
@@ -115,13 +115,10 @@ class PacketAnalysisManager(private val context: Context) {
             TrafficStatistics.updateStats(packetInfo)
 
             // 2. Deep packet inspection (if payload available)
-
+            var extractedPayload: ByteArray? = null
             val enrichedPacket = if (rawPacket != null && rawPacket.isNotEmpty()) {
-                // Extract payload from raw packet
-                val payload = extractPayload(rawPacket, packetInfo)
-
-                val result = PacketDissector.dissect(packetInfo, payload)
-                result
+                extractedPayload = extractPayload(rawPacket, packetInfo)
+                PacketDissector.dissect(packetInfo, extractedPayload)
             } else {
                 packetInfo
             }
@@ -155,8 +152,8 @@ class PacketAnalysisManager(private val context: Context) {
                 }
             }
 
-            // 3. Anomaly detection
-            AnomalyDetector.analyzePacket(finalPacket)
+            // 3. Anomaly detection (pass extracted payload for entropy analysis)
+            AnomalyDetector.analyzePacket(finalPacket, extractedPayload)
             finalPacket["anomalyScore"] = AnomalyDetector.calculateAnomalyScore(finalPacket)
 
             // 4. PCAP export (if active)

--- a/android/app/src/test/kotlin/com/example/packet_analyzer/EntropyTest.kt
+++ b/android/app/src/test/kotlin/com/example/packet_analyzer/EntropyTest.kt
@@ -1,0 +1,52 @@
+package com.example.packet_analyzer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class EntropyTest {
+
+    @Test
+    fun `empty payload returns 0_0`() {
+        val result = AnomalyDetector.calculateEntropy(ByteArray(0))
+        assertEquals(0.0, result, 0.0001)
+    }
+
+    @Test
+    fun `all identical bytes returns 0_0`() {
+        val payload = ByteArray(100) { 0 }
+        val result = AnomalyDetector.calculateEntropy(payload)
+        assertEquals(0.0, result, 0.0001)
+    }
+
+    @Test
+    fun `two alternating byte values returns 1_0`() {
+        // Payload with exactly two distinct values in equal proportion → entropy = 1.0
+        val payload = ByteArray(100) { i -> (i % 2).toByte() }
+        val result = AnomalyDetector.calculateEntropy(payload)
+        assertEquals(1.0, result, 0.0001)
+    }
+
+    @Test
+    fun `256 uniformly distributed bytes returns 8_0`() {
+        // One of each byte value 0-255 → maximum entropy = log2(256) = 8.0
+        val payload = ByteArray(256) { i -> i.toByte() }
+        val result = AnomalyDetector.calculateEntropy(payload)
+        assertEquals(8.0, result, 0.0001)
+    }
+
+    @Test
+    fun `ASCII string returns entropy between 2_0 and 4_0`() {
+        val payload = "Hello World".toByteArray(Charsets.US_ASCII)
+        val result = AnomalyDetector.calculateEntropy(payload)
+        assertTrue("Expected entropy in [2.0, 4.0] but was $result", result >= 2.0 && result <= 4.0)
+    }
+
+    @Test
+    fun `random ByteArray of 1000 bytes returns entropy above 7_5`() {
+        val payload = Random(seed = 42).nextBytes(1000)
+        val result = AnomalyDetector.calculateEntropy(payload)
+        assertTrue("Expected entropy > 7.5 but was $result", result > 7.5)
+    }
+}

--- a/lib/enhanced_ui_components.dart
+++ b/lib/enhanced_ui_components.dart
@@ -331,6 +331,40 @@ class EnhancedPacketCard extends StatelessWidget {
                     ),
                   ],
 
+                  // Entropy Score Badge
+                  if (packet.entropyScore != null &&
+                      packet.entropyScore! > 6.5) ...[
+                    const SizedBox(width: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 6,
+                        vertical: 2,
+                      ),
+                      decoration: BoxDecoration(
+                        color: (packet.entropyScore! > 7.2
+                                ? Colors.red
+                                : Colors.orange)
+                            .withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(
+                          color: packet.entropyScore! > 7.2
+                              ? Colors.red
+                              : Colors.orange,
+                        ),
+                      ),
+                      child: Text(
+                        'E:${packet.entropyScore!.toStringAsFixed(1)}',
+                        style: TextStyle(
+                          fontSize: 10,
+                          color: packet.entropyScore! > 7.2
+                              ? Colors.red
+                              : Colors.orange,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+
                   const Spacer(),
 
                   // Expand Icon

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -991,6 +991,9 @@ class _PacketAnalyzerScreenState extends State<PacketAnalyzerScreen>
     final description = data['description']?.toString() ?? '';
     final sourceIp = data['sourceIp']?.toString() ?? '';
 
+    final showToolSignatures =
+        type == 'DNS_TUNNELING' || type == 'COVERT_CHANNEL';
+
     // Determine color based on severity: CRITICAL (red) > HIGH (orange) > MEDIUM (amber) > LOW (blue)
     final color = switch (severity) {
       'CRITICAL' => Colors.red.shade700,
@@ -1021,6 +1024,11 @@ class _PacketAnalyzerScreenState extends State<PacketAnalyzerScreen>
               Text(
                 'Source: $sourceIp',
                 style: const TextStyle(color: Colors.white70, fontSize: 11),
+              ),
+            if (showToolSignatures)
+              const Text(
+                'Tool signatures: dnscat2, iodine, icmptunnel, ptunnel',
+                style: TextStyle(color: Colors.white54, fontSize: 10),
               ),
           ],
         ),

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -10,6 +10,7 @@ class PacketInfo {
   final Map<String, dynamic>? dpiData;
   final Map<String, dynamic>? payloadAnalysis;
   final double? anomalyScore;
+  final double? entropyScore;
   final Map<String, dynamic>? httpData;
   final Map<String, dynamic>? dnsData;
   final Map<String, dynamic>? tlsData;
@@ -33,6 +34,7 @@ class PacketInfo {
     this.dpiData,
     this.payloadAnalysis,
     this.anomalyScore,
+    this.entropyScore,
     this.httpData,
     this.dnsData,
     this.tlsData,
@@ -89,6 +91,9 @@ class PacketInfo {
       // anomalyScore (0.0-1.0) is populated by AnomalyDetector.calculateAnomalyScore() on Android side
       anomalyScore: map['anomalyScore'] != null
           ? (map['anomalyScore'] as num).toDouble()
+          : null,
+      entropyScore: map['entropyScore'] != null
+          ? (map['entropyScore'] as num).toDouble()
           : null,
       domain: map['domain']?.toString(),
       domainFriendly: map['domainFriendly']?.toString(),


### PR DESCRIPTION
This PR implements entropy-based detection for DNS tunneling and covert channels.

## Changes
- Implemented calculateEntropy() method in AnomalyDetector
- Added HIGH_ENTROPY_PAYLOAD and COVERT_CHANNEL to AnomalyType enum
- Implemented DNS tunneling detection via entropy analysis
- Implemented covert channel detection for ICMP and non-TLS high entropy packets
- Exposed entropy score in analyzePacket() result
- Updated PacketAnalysisManager to pass raw payload bytes
- Added entropyScore field to PacketInfo model
- Show entropy score badge on high-entropy packets in UI
- Display entropy details in anomaly SnackBar
- Added comprehensive unit tests for entropy calculation
- Updated README with entropy detection documentation